### PR TITLE
WL - Group Collection Upon User Login

### DIFF
--- a/AcademicReward/Database/AcademicRewardsDatabase.cs
+++ b/AcademicReward/Database/AcademicRewardsDatabase.cs
@@ -12,8 +12,8 @@ namespace AcademicReward.Database {
         /// InitDatabaseConnection opens up a new
         /// AcademicRewards database connection
         /// 
-        /// IMPORTANT: This needs to be closed after
-        /// the database action has been completed
+        /// IMPORTANT: This needs to be opened and
+        /// closed in the calling method
         /// </summary>
         public NpgsqlConnection InitDatabaseConnection() {
             //Creating the connection string

--- a/AcademicReward/Database/LoginGroupDatabase.cs
+++ b/AcademicReward/Database/LoginGroupDatabase.cs
@@ -1,0 +1,63 @@
+﻿using AcademicReward.ModelClass;
+using AcademicReward.Resources;
+using Npgsql;
+
+namespace AcademicReward.Database {
+    public class LoginGroupDatabase : AcademicRewardsDatabase, IDatabase {
+        public LoginGroupDatabase() { }
+
+        //Currently not needed
+        public DatabaseErrorType AddItem(object obj) {
+            return DatabaseErrorType.NoError;
+        }
+
+        //Currently not needed
+        public DatabaseErrorType UpdateItem(object obj) {
+            return DatabaseErrorType.NoError;
+        }
+
+        //Currently not needed
+        public DatabaseErrorType DeleteItem(object obj) {
+            return DatabaseErrorType.NoError;
+        }
+
+        //Currently not needed
+        public DatabaseErrorType LookupItem(object obj) {
+            return DatabaseErrorType.NoError;
+        }
+
+
+        public DatabaseErrorType LookupFullItem(object profile) {
+            DatabaseErrorType dbError;
+            Profile loggedInProfile = profile as Profile;
+            try {
+                //Opening the connection
+                using var con = new NpgsqlConnection(InitializeConnectionString());
+                con.Open();
+                //Gathering all groups for a given profile
+                var sql = "SELECT * " +
+                          "FROM groups " +
+                          "WHERE groupid IN (SELECT a.groupid " +
+                                            "FROM groups a, profilegroup b " +
+                                            $"WHERE a.groupid = b.groupid AND profileid = {loggedInProfile.ProfileID});";
+                //Executing the query.
+                using var cmd = new NpgsqlCommand(sql, con);
+                using NpgsqlDataReader reader = cmd.ExecuteReader();
+                reader.Read();
+                //Creating all our group objects
+                //[0] -> groupid | [1] -> groupname | [2] -> groupdescription | [3] -> adminprofileid
+                while(reader.Read()) {
+                    Group group = new Group((int)reader[0], reader[1] as string, reader[2] as string, (int)reader[3]);
+                    MauiProgram.Profile.AddGroupToProfile(group);
+                }
+                con.Close();
+                dbError = DatabaseErrorType.NoError;
+            } catch(NpgsqlException ex) {
+                //Some database error occurred
+                Console.WriteLine("Unexpected error while gathering profile groups: {0}", ex);
+                dbError = DatabaseErrorType.LoginGroupCollectionDBError;
+            }
+            return dbError;
+        }
+    }
+}

--- a/AcademicReward/Database/LoginGroupDatabase.cs
+++ b/AcademicReward/Database/LoginGroupDatabase.cs
@@ -3,6 +3,11 @@ using AcademicReward.Resources;
 using Npgsql;
 
 namespace AcademicReward.Database {
+    /// <summary>
+    /// Primary Author: Wil LaLonde
+    /// Secondary Author: None
+    /// Reviewer: 
+    /// </summary>
     public class LoginGroupDatabase : AcademicRewardsDatabase, IDatabase {
         public LoginGroupDatabase() { }
 

--- a/AcademicReward/Database/NotificationDatabase.cs
+++ b/AcademicReward/Database/NotificationDatabase.cs
@@ -1,13 +1,11 @@
 ﻿using AcademicReward.Resources;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AcademicReward.Database {
     public class NotificationDatabase : AcademicRewardsDatabase, IDatabase {
 
+        /// <summary>
+        /// NotificationDatbase constructor
+        /// </summary>
         public NotificationDatabase() { }
 
         public DatabaseErrorType AddItem(object notification) {

--- a/AcademicReward/Logic/LoginGroupLogic.cs
+++ b/AcademicReward/Logic/LoginGroupLogic.cs
@@ -1,8 +1,12 @@
 ﻿using AcademicReward.Database;
-using AcademicReward.ModelClass;
 using AcademicReward.Resources;
 
 namespace AcademicReward.Logic {
+    /// <summary>
+    /// Primary Author: Wil LaLonde
+    /// Secondary Author: 
+    /// Reviewer: 
+    /// </summary>
     public class LoginGroupLogic : ILogic {
         private IDatabase loginGroupDB;
 

--- a/AcademicReward/Logic/LoginGroupLogic.cs
+++ b/AcademicReward/Logic/LoginGroupLogic.cs
@@ -1,0 +1,47 @@
+﻿using AcademicReward.Database;
+using AcademicReward.ModelClass;
+using AcademicReward.Resources;
+
+namespace AcademicReward.Logic {
+    public class LoginGroupLogic : ILogic {
+        private IDatabase loginGroupDB;
+
+        /// <summary>
+        /// LoginGroupLogic constructor
+        /// </summary>
+        public LoginGroupLogic() {
+            loginGroupDB = new LoginGroupDatabase();
+        }
+
+        //Currently not needed
+        public LogicErrorType AddItem(object obj) {
+            return LogicErrorType.NoError;
+        }
+
+        //Currently not needed
+        public LogicErrorType UpdateItem(object obj) {
+            return LogicErrorType.NoError;
+        }
+
+        //Currently not needed
+        public LogicErrorType DeleteItem(object obj) {
+            return LogicErrorType.NoError;
+        }
+
+        /// <summary>
+        /// Method that calls the database to gather 
+        /// </summary>
+        /// <param name="profile"></param>
+        /// <returns></returns>
+        public LogicErrorType LookupItem(object profile) {
+            LogicErrorType logicError;
+            DatabaseErrorType dbError = loginGroupDB.LookupFullItem(profile);
+            if(DatabaseErrorType.NoError == dbError) {
+                logicError = LogicErrorType.NoError;
+            } else {
+                logicError = LogicErrorType.LoginGroupCollectionDBError;
+            }
+            return logicError;
+        }
+    }
+}

--- a/AcademicReward/Logic/NotificationLogic.cs
+++ b/AcademicReward/Logic/NotificationLogic.cs
@@ -1,10 +1,5 @@
 ﻿using AcademicReward.Database;
 using AcademicReward.Resources;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AcademicReward.Logic {
     public class NotificationLogic : ILogic {

--- a/AcademicReward/ModelClass/Group.cs
+++ b/AcademicReward/ModelClass/Group.cs
@@ -7,9 +7,11 @@ namespace AcademicReward.ModelClass {
         private ObservableCollection<Task> groupTaskList;
         private ObservableCollection<Notification> groupNotificationList;
 
+        public int GroupID { get; private set; }
         public string GroupName { get; set; }
         public string GroupDescription { get; set; }
         public Profile GroupAdmin { get; private set; }
+        public int AdminProfileID { get; private set; }
         public ObservableCollection<Profile> GroupMemberList { get { return groupMemberList; } }
         public ObservableCollection<Task> GroupTaskList { get { return groupTaskList; } }
         public ObservableCollection<Notification> GroupNotificationList { get { return groupNotificationList; } }
@@ -28,6 +30,20 @@ namespace AcademicReward.ModelClass {
             groupMemberList = new ObservableCollection<Profile>();
             groupTaskList = new ObservableCollection<Task>();
             groupNotificationList = new ObservableCollection<Notification>();
+        }
+
+        /// <summary>
+        /// Group constructor (when gathering all groups for a profile upon login)
+        /// </summary>
+        /// <param name="groupID">int groupID</param>
+        /// <param name="groupName">string groupName</param>
+        /// <param name="groupDescription">string groupDescription</param>
+        /// <param name="adminProfileID">int adminProfileID</param>
+        public Group(int groupID, string groupName, string groupDescription, int adminProfileID) {
+            GroupID = groupID;
+            GroupName = groupName;
+            GroupDescription = groupDescription;
+            AdminProfileID = adminProfileID;
         }
 
         /// <summary>

--- a/AcademicReward/ModelClass/Notification.cs
+++ b/AcademicReward/ModelClass/Notification.cs
@@ -2,21 +2,40 @@
 
 namespace AcademicReward.ModelClass {
     public class Notification : ObservableObject {
+        public const int MinTitleLength = 0;
+        public const int MaxTitleLength = 50;
+        public const int MinDescriptionLength = 0;
+        public const int MaxDescriptionLength = 250;
 
+        public int NotificationID { get; private set; }
         public string Title { get; set; }
         public string Description { get; set; }
-        public Group Group { get; set; }
+        public int GroupID { get; set; }
 
         /// <summary>
-        /// Notification constructor
+        /// Notification constructor (when making a new Notification)
         /// </summary>
         /// <param name="title">string title</param>
         /// <param name="description">string description</param>
-        /// <param name="group">Group group</param>
-        public Notification(string title, string description, Group group) {
+        /// <param name="groupID">int groupID</param>
+        public Notification(string title, string description, int groupID) {
             Title = title;
             Description = description;
-            Group = group;
+            GroupID = groupID;
+        }
+
+        /// <summary>
+        /// Notification constructor (when getting exisiting Notifications)
+        /// </summary>
+        /// <param name="notificationID">int notificationID</param>
+        /// <param name="title">string title</param>
+        /// <param name="description">string description</param>
+        /// <param name="groupID">int groupID</param>
+        public Notification(int notificationID, string title, string description, int groupID) {
+            NotificationID = notificationID;
+            Title = title;
+            Description = description;
+            GroupID = groupID;
         }
     }
 }

--- a/AcademicReward/ModelClass/Task.cs
+++ b/AcademicReward/ModelClass/Task.cs
@@ -2,6 +2,10 @@
 
 namespace AcademicReward.ModelClass {
     public class Task : ObservableObject {
+        public const int MinTitleLength = 0;
+        public const int MaxTitleLength = 50;
+        public const int MinDescriptionLength = 0;
+        public const int MaxDescriptionLength = 250;
 
         public bool IsChecked { get; set; }
         public string Title { get; set;}

--- a/AcademicReward/Resources/DataConstants.cs
+++ b/AcademicReward/Resources/DataConstants.cs
@@ -29,6 +29,11 @@
         public const string SignProfileInUnknownMessage = "An unknown error occurred while signing you in.";
         //LoginPage constants END
 
+        //Login Group Collection START
+        public const string LoginGroupCollectionTitle = "Group Collection Error";
+        public const string LoginGroupCollectionMessage = "An error occurred while gathering your groups. The application can still be used, but no groups will load. Try logging out and in again.";
+        //Login Group Collection END
+
         //Display Alert START
         public const string OK = "OK";
         public const string Cancel = "Cancel";

--- a/AcademicReward/Resources/Enumerations.cs
+++ b/AcademicReward/Resources/Enumerations.cs
@@ -16,6 +16,10 @@
         SignProfileInDBError,
         //LoginPage END
 
+        //Login Group Collection START
+        LoginGroupCollectionDBError,
+        //Login Group Collection END
+
         //General START
         NoError
         //General END
@@ -29,6 +33,10 @@
         UsernameNotFoundDBError,
         UsernameTakenDBError,
         //LoginPage END
+
+        //Login Group Collection START
+        LoginGroupCollectionDBError,
+        //Login Group Collection END
 
         //General START
         NoError

--- a/AcademicReward/Views/HomePage.xaml.cs
+++ b/AcademicReward/Views/HomePage.xaml.cs
@@ -5,7 +5,7 @@ using System.Collections.ObjectModel;
 using AcademicReward.ModelClass;
 
 public partial class HomePage : ContentPage {
-	public HomePage() {
+    public HomePage() {
 		InitializeComponent();
 		TaskLV.ItemsSource = GetTasks();//need to get all tasks... hardcode some tasks
     }

--- a/AcademicReward/Views/LoginPage.xaml.cs
+++ b/AcademicReward/Views/LoginPage.xaml.cs
@@ -7,10 +7,11 @@ using AcademicReward.Logic;
 using AcademicReward.Resources;
 
 public partial class LoginPage : ContentPage {
-	private ILogic loginLogic;
+	private ILogic loginLogic, loginGroupLogic;
 
 	public LoginPage() {
 		loginLogic = new LoginLogic();
+        loginGroupLogic = new LoginGroupLogic();
 		InitializeComponent();
 	}
 
@@ -31,8 +32,14 @@ public partial class LoginPage : ContentPage {
             } else {
                 appShell.SetTabBars(isAdmin);
             }
-			//Sending user off to the home page!
             Application.Current.MainPage = appShell;
+            //Need to gather all the groups for the given profile.
+            LogicErrorType loginGroupType = loginGroupLogic.LookupItem(MauiProgram.Profile);
+            //There was an issue gathering all the groups, display error message.
+            if(LogicErrorType.LoginGroupCollectionDBError == loginGroupType) {
+                await DisplayAlert(DataConstants.LoginGroupCollectionTitle, DataConstants.LoginGroupCollectionMessage, DataConstants.OK);
+            }
+            //Sending user off to the home page!
             await Shell.Current.GoToAsync($"//{nameof(HomePage)}");
         } else if(LogicErrorType.EmptyUsername == loginType) {
             await DisplayAlert(DataConstants.EmptyUsernameTitle, DataConstants.EmptyUsernameMessage, DataConstants.OK);

--- a/AcademicReward/Views/TaskPage.xaml.cs
+++ b/AcademicReward/Views/TaskPage.xaml.cs
@@ -4,40 +4,12 @@ using CommunityToolkit.Maui.Views;
 namespace AcademicReward.Views;
 
 public partial class TaskPage : ContentPage {
-	public class TestNotification {
-		public TestNotification(string notification) {
-			TestNotificationValue = notification;
-		}
-
-		public string TestNotificationValue { get; set; }
-	}
-
-	public class TestTask {
-		public TestTask(string task) {
-			TestTaskValue = task;
-		}
-
-		public string TestTaskValue { get; set; }
-	}
 
 	public TaskPage() {
-		//Temp notification list for testing
-		List<TestNotification> testNotificationList = new List<TestNotification>();
-		testNotificationList.Add(new TestNotification("Testing Notification 1"));
-        testNotificationList.Add(new TestNotification("Testing Notification 2"));
-        testNotificationList.Add(new TestNotification("Testing Notification 3"));
-        testNotificationList.Add(new TestNotification("Testing Notification 4"));
-        testNotificationList.Add(new TestNotification("Testing Notification 5"));
-		//Temp task list for testing
-		List<TestTask> testTaskList = new List<TestTask>();
-		testTaskList.Add(new TestTask("Testing Task 1"));
-        testTaskList.Add(new TestTask("Testing Task 2"));
-        testTaskList.Add(new TestTask("Testing Task 3"));
-        testTaskList.Add(new TestTask("Testing Task 4"));
-        testTaskList.Add(new TestTask("Testing Task 5"));
         InitializeComponent();
-        NotificationList.ItemsSource = testNotificationList;
-        TaskList.ItemsSource = testTaskList;
+        //Most likely some database calls here to populate the lists
+        //NotificationList.ItemsSource = testNotificationList;
+        //TaskList.ItemsSource = testTaskList;
     }
 
 	private void AddNotificationButtonClicked(object sender, EventArgs e) {


### PR DESCRIPTION
Made a change to collect all groups for a given user upon logging in. This change is needed to show all notification, tasks, and groups. Once a Profile has all the groups associated with it, it should be easier to gather all notifications, tasks, shop items, etc.

Again, this information can be accessed via MauiProgram.Profile. 