### PR TITLE
WL - General Bug Fixes / Enhancements

### DIFF
--- a/AcademicReward/Database/GroupProfileRelationship.cs
+++ b/AcademicReward/Database/GroupProfileRelationship.cs
@@ -23,22 +23,23 @@ namespace AcademicReward.Database {
                 using var con = new NpgsqlConnection(InitializeConnectionString());
                 con.Open();
                 //Select SQL query for getting all profiles
-                var sql = "SELECT * " +
-                    "FROM profiles " +
-                    "WHERE profileid IN (SELECT profileid" +
-                    "                    FROM profilegroup" +
-                    "                    WHERE groupid = " + $"{groupId}" + ");";
+                var sql = "SELECT username, xp, level " +
+                          "FROM profiles " +
+                          "WHERE profileid IN (SELECT profileid " +
+                                              "FROM profilegroup, groups " +
+                                             $"WHERE groups.groupid = {groupId} " +
+                                              "AND profileid != groups.adminprofileid " +
+                                              "AND groups.groupid = profilegroup.groupid);";
                 //Executing the query.
                 using var cmd = new NpgsqlCommand(sql, con);
                 using NpgsqlDataReader reader = cmd.ExecuteReader();
                 //Reading the data
                 ObservableCollection<Profile> profiles = new ObservableCollection<Profile>();
 
-                while (reader.Read()) {
-                    profiles.Add(new Profile(
-                        reader.GetString(1), // Username
-                        reader.GetString(7) // Password
-                    ));
+                while (reader.Read())
+                {
+                    //[0] -> username | [1] -> xp | [2] -> level
+                    profiles.Add(new Profile(reader[0] as string, (int)reader[1], (int)reader[2]));
                 }
 
                 //Closing the connection.

--- a/AcademicReward/Database/TaskDatabase.cs
+++ b/AcademicReward/Database/TaskDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using AcademicReward.Resources;
+using AcademicReward.ModelClass;
 using Npgsql;
 using System.Collections.ObjectModel;
 
@@ -189,7 +190,7 @@ namespace AcademicReward.Database {
         /// <returns>DatabaseErrorType</returns>
         public DatabaseErrorType LookupFullItem(object profile) {
             DatabaseErrorType dbError;
-            ModelClass.Profile profileTasks = profile as ModelClass.Profile;
+            Profile profileTasks = profile as Profile;
             if (profileTasks.IsAdmin) { //This is for fetching data for ADMIN VIEW 
                 try {
                     //Opening the connection

--- a/AcademicReward/ModelClass/Profile.cs
+++ b/AcademicReward/ModelClass/Profile.cs
@@ -92,6 +92,18 @@ namespace AcademicReward.ModelClass {
         }
 
         /// <summary>
+        /// Profile constructor (when showing members in a group)
+        /// </summary>
+        /// <param name="username">string username</param>
+        /// <param name="level">int level</param>
+        /// <param name="xp">int xp</param>
+        public Profile(string username, int xp, int level) {
+            Username = username;
+            XP = xp;
+            Level = level;
+        }
+
+        /// <summary>
         /// Profile constructor (when fully logged in)
         /// Parameters match the DB columns
         /// </summary>

--- a/AcademicReward/PopUps/TaskPopup.xaml
+++ b/AcademicReward/PopUps/TaskPopup.xaml
@@ -81,7 +81,7 @@
             <!--Group-->
             <HorizontalStackLayout >
                 <Label
-                Text="GroupID:"
+                Text="Group Name:"
                 FontSize="28"
                 Margin="0, 5, 10,0" 
                 FontAttributes="Bold"/>

--- a/AcademicReward/PopUps/TaskPopup.xaml.cs
+++ b/AcademicReward/PopUps/TaskPopup.xaml.cs
@@ -35,7 +35,7 @@ public partial class TaskPopUp : Popup {
         title.Text = selectedTask.Title;
         description.Text = selectedTask.Description;
         points.Text = selectedTask.Points.ToString();
-        group.Text = selectedTask.GroupID.ToString();
+        group.Text = MauiProgram.Profile.GetGroupNameUsingGroupID(selectedTask.GroupID);
         SetErrorMessageBox(false, string.Empty);
         isAdmin = MauiProgram.Profile.IsAdmin;
        

--- a/AcademicReward/Views/GroupPage.xaml
+++ b/AcademicReward/Views/GroupPage.xaml
@@ -17,13 +17,19 @@
                         TextDecorations="Underline"
                         FontAttributes="Bold"
                         HorizontalOptions="Center"/>
-                    <Label
-                        x:Name="GroupAdminLbl"
-                        Text="{ Binding AdminName }"
-                        FontSize="35"
-                        FontFamily="SecondaryFont"
-                        TextColor="{StaticResource Gray600}"
-                        HorizontalOptions="Center"/>
+                    <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+                        <Label
+                            Text="Admin: "
+                            FontSize="35"
+                            FontFamily="SecondaryFont"
+                            TextColor="{StaticResource Gray600}"/>
+                        <Label
+                            x:Name="GroupAdminLbl"
+                            Text="{ Binding AdminName }"
+                            FontSize="35"
+                            FontFamily="SecondaryFont"
+                            TextColor="{StaticResource Gray600}"/>
+                    </StackLayout>
                     <Label
                         x:Name="GroupDescriptionLbl"
                         Text="{ Binding GroupDescription }"
@@ -65,11 +71,38 @@
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <ViewCell>
-                                <Label
-                                    FontSize="25"
-                                    Text="{Binding Username}"
-                                    VerticalOptions="Center"
-                                    HorizontalOptions="Center"/>
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="5*"/>
+                                        <ColumnDefinition Width="2*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Label 
+                                        Grid.Row="0" 
+                                        Grid.Column="0" 
+                                        Text="{Binding Level, StringFormat='Lvl: {0}'}"
+                                        FontSize="25"
+                                        Padding="5"
+                                        VerticalOptions="Center"/>
+                                    <Label 
+                                        Grid.Row="0" 
+                                        Grid.Column="1" 
+                                        Text="{Binding Username}"
+                                        FontSize="25"
+                                        Padding="5"
+                                        VerticalOptions="Center"/>
+                                    <Label 
+                                        Grid.Row="0" 
+                                        Grid.Column="2" 
+                                        Text="{Binding XP, StringFormat='XP: {0}/100'}"
+                                        FontSize="25"
+                                        Padding="5"
+                                        VerticalOptions="Center"
+                                        HorizontalOptions="EndAndExpand"/>
+                                </Grid>
                             </ViewCell>
                         </DataTemplate>
                 </ListView.ItemTemplate>

--- a/AcademicReward/Views/GroupPage.xaml.cs
+++ b/AcademicReward/Views/GroupPage.xaml.cs
@@ -26,6 +26,7 @@ public partial class GroupPage : ContentPage {
         this.group = group;
 
         Members = GroupProfileRelationship.getProfilesInGroup(group);
+        UpdateMembersXP();
         MembersLV.ItemsSource = Members;
 
         GroupDescriptionLbl.Text = group.GroupDescription;
@@ -65,8 +66,18 @@ public partial class GroupPage : ContentPage {
         if (result is ObservableCollection<Profile> membersResult) {
             if (membersResult != null) {
                 Members = GroupProfileRelationship.getProfilesInGroup(group);
+                UpdateMembersXP();
                 MembersLV.ItemsSource = Members;
             }
+        }
+    }
+
+    /// <summary>
+    /// Helper method used to properly show the correct amount of XP for a member
+    /// </summary>
+    private void UpdateMembersXP() {
+        foreach(Profile member in Members) {
+            member.XP = member.GetCurrentXPInt();
         }
     }
 }

--- a/AcademicReward/Views/HomePage.xaml.cs
+++ b/AcademicReward/Views/HomePage.xaml.cs
@@ -32,10 +32,9 @@ public partial class HomePage : ContentPage {
         history = new HistoryDatabase();
         updateProfile = new ProfileLogic();
         isAdmin = MauiProgram.Profile.IsAdmin;
-		UsernameDisplay(isAdmin);
         PrepareTaskList();
         RefreshTaskList();
-        
+        UsernameDisplay(isAdmin);
     }
 
     /// <summary>

--- a/AcademicReward/Views/NotificationPage.xaml
+++ b/AcademicReward/Views/NotificationPage.xaml
@@ -7,7 +7,7 @@
     <!-- Secondary Author: None -->
     <!-- Reviewer: Maximilian Patterson -->
     <ScrollView>
-        <StackLayout Margin="20">
+        <StackLayout Margin="25">
             <Frame BorderColor="{StaticResource BlueButton}">
                 <StackLayout>
                     <Label 

--- a/AcademicReward/Views/TaskPage.xaml
+++ b/AcademicReward/Views/TaskPage.xaml
@@ -7,7 +7,7 @@
     <!-- Secondary Author: None -->
     <!-- Reviewer: Xee Lo -->
     <ScrollView>
-        <StackLayout Margin="20">
+        <StackLayout Margin="25">
             <Frame BorderColor="{StaticResource BlueButton}">
                 <StackLayout Orientation="Horizontal">
                     <StackLayout Orientation="Vertical">


### PR DESCRIPTION
Fixed a few bugs with this PR

1. The admin will no longer show in the member list when clicking on a group
2. When an admin finishes approving a member's task, the home page was not properly showing the new xp, points, level when the member logged in. Just needed to show the username data at a later point in the constructor

Enhancements:
1. When clicking on a task on the home page, it will now show the Group Name instead of the GroupID. (NOTE: the groupID will still show on the home page list)
2. Member's level and xp will now show on the group member list view.
3. Changed the margin on both the Task and Notification page to match the rest of the application.