### PR TITLE
WL - Shop Admin/Member Rework

### DIFF
--- a/AcademicReward/Database/ShopItemDatabase.cs
+++ b/AcademicReward/Database/ShopItemDatabase.cs
@@ -1,7 +1,6 @@
 ﻿using AcademicReward.Resources;
 using AcademicReward.ModelClass;
 using Npgsql;
-using AcademicReward.Logic;
 using System.Collections.ObjectModel;
 
 namespace AcademicReward.Database {
@@ -13,45 +12,47 @@ namespace AcademicReward.Database {
     /// Reviewer: Wil LaLonde
     /// </summary>
     public class ShopItemDatabase : AcademicRewardsDatabase, IDatabase {
-        ShopLogic logic;
 
         /// <summary>
         /// ShopItemDatabase constructor
         /// </summary>
-        /// <param name="ShopLogic">ShopLogic shoplogic</param>
-        public ShopItemDatabase(ShopLogic ShopLogic) {
-            logic = ShopLogic;
-        }
-        public DatabaseErrorType BuyItem(object obj)
-        {
-            DatabaseErrorType dbError = DatabaseErrorType.BuyItemError;
-            try
-            {
-                ShopItem item = (ShopItem)obj;
+        public ShopItemDatabase() { }
+
+        /// <summary>
+        /// Method used to buy a shop item (database)
+        /// </summary>
+        /// <param name="shopItem">object shopItem</param>
+        /// <returns>DatabaseErrorType</returns>
+        public DatabaseErrorType BuyItem(object shopItem) {
+            DatabaseErrorType dbError;
+            ShopItem shopItemToBuy = shopItem as ShopItem;
+            try {
                 //Opening the connection
                 using var con = new NpgsqlConnection(InitializeConnectionString());
                 con.Open();
                 //Insert SQL query for adding a profile
                 var sql = "INSERT INTO purchasedshopitems (profileid, shopitemid)" +
-                          $"VALUES ({MauiProgram.Profile.ProfileID}, '{item.Id}');";
+                          $"VALUES ({MauiProgram.Profile.ProfileID}, '{shopItemToBuy.Id}');";
                 //Executing the query.
                 using var cmd = new NpgsqlCommand(sql, con);
                 cmd.ExecuteNonQuery();
                 //Closing the connection.
                 con.Close();
+                //Remove shop item from member view
+                MauiProgram.Profile.ProfileShop.RemoveShopItemFromShop(shopItemToBuy);
+                //Update member points
+                MauiProgram.Profile.RemovePointsFromMember(shopItemToBuy.PointCost);
+                //Call database to update point values
+                IDatabase profileDB = new ProfileDatabase();
+                profileDB.UpdateItem(MauiProgram.Profile);
                 dbError = DatabaseErrorType.NoError;
-            }
-            catch (PostgresException ex)
-            {
-                //Username already exists.
-                Console.WriteLine("Error while adding item: {0}", ex);
-
-            }
-            catch (NpgsqlException ex)
-            {
+            } catch (PostgresException ex) {
+                Console.WriteLine("Error while buying item: {0}", ex);
+                dbError = DatabaseErrorType.BuyItemError;
+            } catch (NpgsqlException ex) {
                 //Not sure what happened, log message
-                Console.WriteLine("Unexpected error while adding item: {0}", ex);
-
+                Console.WriteLine("Unexpected error while buying item: {0}", ex);
+                dbError = DatabaseErrorType.BuyItemError;
             }
             return dbError;
         }
@@ -81,6 +82,7 @@ namespace AcademicReward.Database {
                     shopItemID = (int)reader[0];
                     //Assigning new id to the shopItem object
                     shopItemToAdd.Id = shopItemID;
+                    MauiProgram.Profile.ProfileShop.AddShopItemToShop(shopItemToAdd);
                 }
                 con.Close();
                 dbError = DatabaseErrorType.NoError;
@@ -101,29 +103,36 @@ namespace AcademicReward.Database {
         /// <summary>
         /// Method used to delete a shop item
         /// </summary>
-        /// <param name="obj">object obj</param>
+        /// <param name="shopItem">object shopItem</param>
         /// <returns>DatabaseErrorType dbError</returns>
-        public DatabaseErrorType DeleteItem(object obj) {
+        public DatabaseErrorType DeleteItem(object shopItem) {
+            DatabaseErrorType dbError;
+            ShopItem shopItemToDelete = shopItem as ShopItem;
             try {
-                ShopItem item = obj as ShopItem;
                 //Opening the connection
                 using var con = new NpgsqlConnection(InitializeConnectionString());
                 con.Open();
-                //SQL to lookup notifications for a group
-                var sql = "DELETE FROM shopitems WHERE shopitemid = '" + item.Id + "';"; 
+                //SQL to delete the shop item
+                var sql = "DELETE FROM shopitems " +
+                         $"WHERE shopitemid = {shopItemToDelete.Id};" +
+                          "DELETE FROM purchasedshopitems " +
+                         $"WHERE shopitemid = {shopItemToDelete.Id};"; 
                 //Executing the query.
                 using var cmd = new NpgsqlCommand(sql, con);
-                using NpgsqlDataReader reader = cmd.ExecuteReader();
-
+                cmd.ExecuteNonQuery();
+                
                 //Closing the connection.
                 con.Close();
-                return DatabaseErrorType.NoError;
+                //Remove item from shopitem list
+                MauiProgram.Profile.ProfileShop.RemoveShopItemFromShop(shopItemToDelete);
+                dbError = DatabaseErrorType.NoError;
             }
             catch (NpgsqlException ex) {
                 //Something went wrong deleting the shop item
                 Console.WriteLine("Unexpected error while deleting the shop item: {0}", ex);
+                dbError = DatabaseErrorType.DeleteShopItemDBError;
             }
-            return DatabaseErrorType.NoError;
+            return dbError;
         }
 
         //Currently not needed
@@ -139,67 +148,53 @@ namespace AcademicReward.Database {
         /// <summary>
         /// Method used to lookup all shop items (database)
         /// </summary>
-        /// <param name="obj">object obj</param>
+        /// <param name="profile">object profile</param>
         /// <returns>DatabaseErrorType dbError</returns>
-        public DatabaseErrorType LookupFullItem(object obj) {
-            ObservableCollection<ShopItem> newList = new ObservableCollection<ShopItem>();
+        public DatabaseErrorType LookupFullItem(object profile) {
+            DatabaseErrorType dbError;
+            Profile profileToLookup = profile as Profile;
             try {
                 //Opening the connection
                 using var con = new NpgsqlConnection(InitializeConnectionString());
                 con.Open();
-                //SQL to lookup notifications for a group
-                var sql = "SELECT * " +
-                            "FROM shopitems;";
+                //SQL to lookup shop items for a given profile
+                var sql = "";
+                if(profileToLookup.IsAdmin) {
+                    //Admins will be able to see all shop items for their groups
+                    sql = "SELECT * " +
+                          "FROM shopitems " +
+                          "WHERE groupid IN (SELECT groupid " +
+                                            "FROM profilegroup " +
+                                           $"WHERE profileid = {profileToLookup.ProfileID});";
+                } else {
+                    //Members will be able to see all shop items they have not purhcased yet
+                    sql = "SELECT * " +
+                          "FROM shopitems " +
+                          "WHERE groupid IN (SELECT groupid " +
+                                            "FROM profilegroup " +
+                                           $"WHERE profileid = {profileToLookup.ProfileID} AND shopitemid NOT IN (SELECT shopitemid " +
+                                                                                                                 "FROM purchasedshopitems " +
+                                                                                                                $"WHERE profileid = {profileToLookup.ProfileID})" +
+                                           ");";
+                }
                 //Executing the query.
                 using var cmd = new NpgsqlCommand(sql, con);
                 using NpgsqlDataReader reader = cmd.ExecuteReader();
                     
-
-                    while (reader.Read())
-                    {
-                        Profile profile = MauiProgram.Profile;
-                        int groupID = (int)reader[5]; //Getting group ID
-                        bool idPresent = false;
-                        Group gettingGroup = null;
-                        bool alreadyPurchased = false;
-                        foreach (Group g in profile.GroupList) //Check the group list for this profile to see if it uses that ID
-                        {
-                            if(g.GroupID == groupID) //If it does use that ID, mark the corresponding group and mark that the user is part of this group
-                            {
-                            idPresent = true;   
-                            gettingGroup = g;
-                            }
-                        }
-                        foreach( ShopItem i in profile.PurchaseItems)
-                        {
-                            if( i.Id == (int)reader[0])
-                            {
-                                alreadyPurchased = true;
-                            }
-                        }
-                        if (idPresent && ! alreadyPurchased)  //If the item is for a group this user is in,
-                                                              //and the item hasn't already been purchased,
-                                                              //add the item to the list the user will see
-                        {
-                        ShopItem item = new ShopItem((int)reader[0], reader[1] as string, reader[2] as string, 
-                            (int)reader[3], (int)reader[4], gettingGroup);
-
-                        newList.Add(item);
-                        }
-                      
-                        
+                while (reader.Read()) {
+                    ShopItem shopItem = new ShopItem((int)reader[0], reader[1] as string, reader[2] as string, (int)reader[3], (int)reader[4], profileToLookup.GetGroupUsingGroupID((int)reader[5]));
+                    //Add shop item to the profile shop
+                    MauiProgram.Profile.ProfileShop.AddShopItemToShop(shopItem);
                 }
-                logic.ItemList = newList;
                 //Closing the connection.
                 con.Close();
-                return DatabaseErrorType.NoError;
-            }
-            catch (NpgsqlException ex) {
+                dbError = DatabaseErrorType.NoError;
+            } catch (NpgsqlException ex) {
                 //Something went wrong looking up shop items
                 Console.WriteLine("Unexpected error while looking up shopitems: {0}", ex);
-                   
-            }
-            return DatabaseErrorType.NoError;
+                dbError = DatabaseErrorType.LookupAllShopItemsDBError;
+            } 
+            return dbError;
         }
 
         //Currently not needed
@@ -210,31 +205,33 @@ namespace AcademicReward.Database {
         /// <summary>
         /// Method used to update a shop item (database)
         /// </summary>
-        /// <param name="obj">object obj</param>
+        /// <param name="shopItem">object shopItem</param>
         /// <returns>DatabaseErrorType dbError</returns>
-        public DatabaseErrorType UpdateItem(object obj) {
+        public DatabaseErrorType UpdateItem(object shopItem) {
+            DatabaseErrorType dbError;
             try {
-                ShopItem item = obj as ShopItem;
+                ShopItem shopItemToUpdate = shopItem as ShopItem;
                 //Opening the connection
                 using var con = new NpgsqlConnection(InitializeConnectionString());
                 con.Open();
                 //SQL to lookup notifications for a group
-                var sql = "UPDATE shopitems SET  " +
-                    $"itemtitle='{item.Title}', itemdescription='{item.Description}', pointcost={item.PointCost}, " +
-                    $"levelrequirment={item.LevelRequirement} WHERE shopitemid={item.Id};";
+                var sql = "UPDATE shopitems SET " +
+                    $"itemtitle = '{shopItemToUpdate.Title}', itemdescription = '{shopItemToUpdate.Description}', pointcost = {shopItemToUpdate.PointCost}, " +
+                    $"levelrequirment = {shopItemToUpdate.LevelRequirement} WHERE shopitemid = {shopItemToUpdate.Id};";
                 //Executing the query.
                 using var cmd = new NpgsqlCommand(sql, con);
-                using NpgsqlDataReader reader = cmd.ExecuteReader();
+                cmd.ExecuteNonQuery();
 
                 //Closing the connection.
                 con.Close();
-                return DatabaseErrorType.NoError;
+                dbError = DatabaseErrorType.NoError;
             }
             catch (NpgsqlException ex) {
                 //Something went wrong updating the shop item
                 Console.WriteLine("Unexpected error updating the shopitem: {0}", ex);
+                dbError = DatabaseErrorType.UpdateShopItemDBError;
             }
-            return DatabaseErrorType.NoError;
+            return dbError;
         }
     }
 }

--- a/AcademicReward/Logic/ShopLogic.cs
+++ b/AcademicReward/Logic/ShopLogic.cs
@@ -33,6 +33,9 @@ namespace AcademicReward.Logic {
                 DatabaseErrorType dbError = shopDB.BuyItem(shopItem);
                 if(DatabaseErrorType.NoError == dbError) {
                     logicError = LogicErrorType.NoError;
+                    //Add new history item
+                    historyDB.AddItem(new HistoryItem(MauiProgram.Profile.ProfileID, DataConstants.HistoryBuyShopItemTitle,
+                       string.Format(DataConstants.HistoryBuyShopItemDescription, shopItem.Title, shopItem.Group.GroupName)));
                 } else {
                     logicError = LogicErrorType.BuyItemError;
                 }

--- a/AcademicReward/ModelClass/Profile.cs
+++ b/AcademicReward/ModelClass/Profile.cs
@@ -21,6 +21,8 @@ namespace AcademicReward.ModelClass {
         private ObservableCollection<Notification> notificationList;
         private ObservableCollection<Task> taskList;
 
+        private int points;
+
         public int ProfileID { get; private set; }
         public string Username { get; set; }
         public string Password { get; set; }
@@ -30,7 +32,11 @@ namespace AcademicReward.ModelClass {
         public bool IsAdmin { get; private set; }
         public int XP { get; set; }
         public int Level { get; set; }
-        public int Points { get; set; }
+        public int Points {
+            get { return points; }
+            set { SetProperty(ref points, value); }
+        }
+        public Shop ProfileShop { get; private set; }
 
         public ObservableCollection<Group> GroupList { get { return groupList; } }
         public ObservableCollection<ShopItem> PurchaseItems { get { return purchaseItems; } }
@@ -128,6 +134,7 @@ namespace AcademicReward.ModelClass {
             purchaseItems = new ObservableCollection<ShopItem>();
             notificationList = new ObservableCollection<Notification>();
             taskList = new ObservableCollection<Task>();
+            ProfileShop = new Shop();
         }
 
         /// <summary>
@@ -217,6 +224,20 @@ namespace AcademicReward.ModelClass {
                 }
             }
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Method used to get the group object using the groupID
+        /// </summary>
+        /// <param name="groupID">int groupID</param>
+        /// <returns>Group group</returns>
+        public Group GetGroupUsingGroupID(int groupID) {
+            foreach(Group group in groupList) {
+                if(group.GroupID == groupID) {
+                    return group;
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/AcademicReward/ModelClass/Shop.cs
+++ b/AcademicReward/ModelClass/Shop.cs
@@ -11,6 +11,8 @@ namespace AcademicReward.ModelClass {
     public class Shop : ObservableObject {
         private ObservableCollection<ShopItem> shopItemList;
 
+        public ObservableCollection<ShopItem> ShopItemList { get { return shopItemList; } }
+
         /// <summary>
         /// Shop constructor
         /// </summary>
@@ -32,17 +34,6 @@ namespace AcademicReward.ModelClass {
         /// <param name="shopItem">ShopItem shopItem</param>
         public void RemoveShopItemFromShop(ShopItem shopItem) {
             shopItemList.Remove(shopItem);
-        }
-
-        /// <summary>
-        /// Edits a given shop item by replacing the variables in the shop item with new, editted variables.
-        /// </summary>
-        /// <param name="ShopItem">ShopItem shopItem</param>
-        /// <param name="newValues">The new shopitem which will take ShopItems place</param>
-        public void editShopItemFromShop(ShopItem ShopItem, ShopItem newValues) {
-            newValues.Id = ShopItem.Id;
-            RemoveShopItemFromShop(ShopItem);
-            AddShopItemToShop(newValues);
         }
     }
 }

--- a/AcademicReward/ModelClass/ShopItem.cs
+++ b/AcademicReward/ModelClass/ShopItem.cs
@@ -14,15 +14,40 @@ namespace AcademicReward.ModelClass {
         public const int MaxDescriptionLength = 250;
         public const int MinCostValue = 0;
         public const int MinLevelRequirement = 1;
+        public const int DeleteShopItemSuccesValue = -1;
+        public const int BuyShopItemSuccessValue = -2;
 
+        private int id;
+        private string title;
+        private string description;
+        private int pointCost;
+        private int levelRequirement;
+        private Group group;
 
-        public static int IdCounter = 0;
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public int PointCost { get; set; }
-        public int LevelRequirement { get; set; }
-        public Group Group { get; set; }
+        public int Id {
+            get { return id; }
+            set { SetProperty(ref id, value); }
+        }
+        public string Title {
+            get { return title; }
+            set { SetProperty(ref title, value); }
+        }
+        public string Description {
+            get { return description; }
+            set { SetProperty(ref description, value); }
+        }
+        public int PointCost {
+            get { return pointCost; }
+            set { SetProperty(ref pointCost, value); }
+        }
+        public int LevelRequirement {
+            get { return levelRequirement; }
+            set { SetProperty(ref levelRequirement, value); }
+        }
+        public Group Group {
+            get { return group; }
+            set { SetProperty(ref group, value); }
+        }
 
         /// <summary>
         /// ShopItem constructor
@@ -38,7 +63,6 @@ namespace AcademicReward.ModelClass {
             PointCost = pointCost;
             LevelRequirement = levelRequirement;
             Group = group;
-            Id = ++IdCounter;
         }
 
         /// <summary>
@@ -57,9 +81,6 @@ namespace AcademicReward.ModelClass {
             PointCost = pointCost;
             LevelRequirement = levelRequirement;
             Group = group;
-            if (id > IdCounter) {
-                IdCounter = id++;               //This prevents overlapping IDs
-            }
         }
     }
 }

--- a/AcademicReward/ModelClass/ShopItem.cs
+++ b/AcademicReward/ModelClass/ShopItem.cs
@@ -8,6 +8,13 @@ namespace AcademicReward.ModelClass {
     /// Reviewer: Maximilian Patterson
     /// </summary>
     public class ShopItem : ObservableObject {
+        public const int MinTitleLength = 0;
+        public const int MaxTitleLength = 50;
+        public const int MinDescriptionLength = 0;
+        public const int MaxDescriptionLength = 250;
+        public const int MinCostValue = 0;
+        public const int MinLevelRequirement = 1;
+
 
         public static int IdCounter = 0;
         public int Id { get; set; }

--- a/AcademicReward/PopUps/AddShopItemPage.xaml
+++ b/AcademicReward/PopUps/AddShopItemPage.xaml
@@ -6,8 +6,8 @@
             CanBeDismissedByTappingOutsideOfPopup="False"
             Color="White"
             Size="600, 1100">
-    <!-- Primary Author: Wil LaLonde -->
-    <!-- Secondary Author: Sean Stille -->
+    <!-- Primary Author: Sean Stille -->
+    <!-- Secondary Author: Wil LaLonde -->
     <!-- Reviewer: Wil LaLonde -->
     <StackLayout Margin="25">
         <StackLayout Orientation="Horizontal" Margin="0, 20">
@@ -30,7 +30,7 @@
         <Frame x:Name="ErrorFrame" BackgroundColor="{StaticResource ErrorBackgroundColor}" BorderColor="{StaticResource ErrorBorderColor}"  Margin="10, 0">
             <StackLayout x:Name="ErrorStackLayout">
                 <Label
-                    Text="Error with task creation: "
+                    Text="Error while adding shop item: "
                     x:Name="ErrorMessageHeader"
                     FontSize="22"
                     Margin="0, 5"
@@ -38,7 +38,6 @@
                 <Label
                     Text=""
                     x:Name="ErrorMessageBody"
-                    TextType="Html"
                     FontSize="20"/>
             </StackLayout>
         </Frame>

--- a/AcademicReward/PopUps/AddShopItemPage.xaml
+++ b/AcademicReward/PopUps/AddShopItemPage.xaml
@@ -4,9 +4,10 @@
             xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
             x:Class="AcademicReward.AddShopItemPage"
             CanBeDismissedByTappingOutsideOfPopup="False"
-            Color="White">
-    <!-- Primary Author: Sean Stille -->
-    <!-- Secondary Author: Wil LaLonde -->
+            Color="White"
+            Size="600, 1100">
+    <!-- Primary Author: Wil LaLonde -->
+    <!-- Secondary Author: Sean Stille -->
     <!-- Reviewer: Wil LaLonde -->
     <StackLayout Margin="25">
         <StackLayout Orientation="Horizontal" Margin="0, 20">
@@ -26,7 +27,21 @@
                     TextDecorations="Underline"/>
             </Frame>
         </StackLayout>
-
+        <Frame x:Name="ErrorFrame" BackgroundColor="{StaticResource ErrorBackgroundColor}" BorderColor="{StaticResource ErrorBorderColor}"  Margin="10, 0">
+            <StackLayout x:Name="ErrorStackLayout">
+                <Label
+                    Text="Error with task creation: "
+                    x:Name="ErrorMessageHeader"
+                    FontSize="22"
+                    Margin="0, 5"
+                    FontAttributes="Bold"/>
+                <Label
+                    Text=""
+                    x:Name="ErrorMessageBody"
+                    TextType="Html"
+                    FontSize="20"/>
+            </StackLayout>
+        </Frame>
         <StackLayout Margin="10">
             <Label
                 Text="Item Name:"

--- a/AcademicReward/PopUps/AddShopItemPage.xaml.cs
+++ b/AcademicReward/PopUps/AddShopItemPage.xaml.cs
@@ -2,6 +2,9 @@ namespace AcademicReward;
 
 using AcademicReward.Logic;
 using CommunityToolkit.Maui.Views;
+using AcademicReward.Resources;
+using AcademicReward.ModelClass;
+using System.Text;
 
 /// <summary>
 /// AddShopItemPage is the popup when adding a new shop item
@@ -10,7 +13,7 @@ using CommunityToolkit.Maui.Views;
 /// Reviewer: Wil LaLonde
 /// </summary>
 public partial class AddShopItemPage : Popup {
-	ILogic logic;
+	ILogic shopLogic;
 
 	/// <summary>
 	/// AddShopItemPage constructor
@@ -18,9 +21,11 @@ public partial class AddShopItemPage : Popup {
 	/// <param name="ShopLogic">ILogic ShopLogic</param>
 	public AddShopItemPage(ILogic ShopLogic) {
 		InitializeComponent();
-		logic = ShopLogic;
+        shopLogic = ShopLogic;
 		GroupPicker.ItemsSource = MauiProgram.Profile.GroupList;
-	}
+        //Hide all the error elements
+        SetErrorMessageBox(false, string.Empty);
+    }
 
 	/// <summary>
 	/// Method called when a user clicks the add button
@@ -28,15 +33,33 @@ public partial class AddShopItemPage : Popup {
 	/// <param name="sender">object sender</param>
 	/// <param name="e">EventArgs e</param>
 	private void AddClicked(object sender, EventArgs e) {
-		String itemName = name.Text;
-		String itemDesc = description.Text;
-		String itemCost = cost.Text;
-		string itemLevel = levelRec.Text;
-		String itemGroup = ""; //Not sure how to pull this from the array of groups
-		String[] itemValues = { name.Text, description.Text, cost.Text, levelRec.Text, itemGroup, GroupPicker.SelectedIndex + ""};
-		logic.AddItem(itemValues);
-		
-		Close();
+		LogicErrorType logicError;
+		Group selectedGroup = GroupPicker.SelectedItem as Group;
+		if (selectedGroup != null) {
+			string itemName = name.Text ?? string.Empty;
+			string itemDescription = name.Text ?? string.Empty;
+			bool isValidItemCost = int.TryParse(cost.Text, out int itemCost);
+			if(isValidItemCost) {
+				bool isValidLevelRequirement = int.TryParse(levelRec.Text, out int levelRequirement);
+				if(isValidLevelRequirement) {
+					//Create ShopItem object
+					ShopItem shopItemToAdd = new ShopItem(itemName, itemDescription, itemCost, levelRequirement, selectedGroup);
+					logicError = shopLogic.AddItem(shopItemToAdd);
+					//Shop item was added successfully
+					if(LogicErrorType.NoError == logicError) {
+						Close(shopItemToAdd);
+					}
+                } else {
+					logicError = LogicErrorType.InvalidLevel;
+				}
+			} else {
+				logicError = LogicErrorType.InvalidCost;
+            }
+		} else {
+			logicError = LogicErrorType.EmptyShopItemGroup;
+        }
+        // There was some kind of error, show messages
+        SetErrorMessageBox(true, SetErrorMessageBody(logicError));
 	}
 
 	/// <summary>
@@ -45,4 +68,74 @@ public partial class AddShopItemPage : Popup {
 	/// <param name="sender">object sender</param>
 	/// <param name="e">EventArgs e</param>
     private void BackButtonClicked(object sender, EventArgs e) => Close();
+
+    /// <summary>
+    /// Helper method used to either show or hide the error message box
+    /// This is done since a popup cannot have another popup
+    /// </summary>
+    /// <param name="isVisible">bool isVisible</param>
+    /// <param name="errorMessage">string errorMessage</param>
+    private void SetErrorMessageBox(bool isVisible, string errorMessage) {
+        ErrorFrame.IsVisible = isVisible;
+        ErrorStackLayout.IsVisible = isVisible;
+        ErrorMessageHeader.IsVisible = isVisible;
+        ErrorMessageBody.IsVisible = isVisible;
+        ErrorMessageBody.Text = errorMessage;
+    }
+
+	/// <summary>
+	/// Helper method used to determine what error message to display.
+	/// </summary>
+	/// <param name="logicError">LogicErrorType logicError</param>
+	/// <returns>string errorMessage</returns>
+	private string SetErrorMessageBody(LogicErrorType logicError) {
+		StringBuilder errorMessageBuilder = new StringBuilder();
+		switch(logicError) {
+			case LogicErrorType.EmptyShopItemGroup:
+				errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+				errorMessageBuilder.Append(DataConstants.EmptyGroupNameMessage);
+				break;
+			case LogicErrorType.InvalidCost:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidItemCostMessage);
+                break;
+			case LogicErrorType.InvalidLevel:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidLevelMessage);
+                break;
+			case LogicErrorType.EmptyShopItemTitle:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemTitleMessage);
+                break;
+			case LogicErrorType.EmptyTaskDescription:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemDescriptionMessage);
+                break;
+            case LogicErrorType.NegativeShopItemCost:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.NegativeShopItemCostMessage);
+                break;
+            case LogicErrorType.NegativeShopItemLevelRequirement:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.NegativeShopItemLevelRequirementMessage);
+                break;
+            case LogicErrorType.InvalidShopItemLength:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidShopItemTitleLengthMessage);
+                break;
+            case LogicErrorType.InvalidShopItemDescriptionLength:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidShopItemDescriptionLengthMessage);
+                break;
+			case LogicErrorType.AddShopItemDBError:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.AddShopItemDBErrorMessage);
+                break;
+			default;
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.AddShopItemUnknownErrorMessage);
+                break;
+        }
+		return errorMessageBuilder.ToString();
+	}
 }

--- a/AcademicReward/PopUps/AddShopItemPage.xaml.cs
+++ b/AcademicReward/PopUps/AddShopItemPage.xaml.cs
@@ -9,7 +9,7 @@ using System.Text;
 /// <summary>
 /// AddShopItemPage is the popup when adding a new shop item
 /// Primary Author: Sean Stille
-/// Secondary Author: None
+/// Secondary Author: Wil LaLonde
 /// Reviewer: Wil LaLonde
 /// </summary>
 public partial class AddShopItemPage : Popup {
@@ -37,7 +37,7 @@ public partial class AddShopItemPage : Popup {
 		Group selectedGroup = GroupPicker.SelectedItem as Group;
 		if (selectedGroup != null) {
 			string itemName = name.Text ?? string.Empty;
-			string itemDescription = name.Text ?? string.Empty;
+			string itemDescription = description.Text ?? string.Empty;
 			bool isValidItemCost = int.TryParse(cost.Text, out int itemCost);
 			if(isValidItemCost) {
 				bool isValidLevelRequirement = int.TryParse(levelRec.Text, out int levelRequirement);
@@ -93,8 +93,16 @@ public partial class AddShopItemPage : Popup {
 		switch(logicError) {
 			case LogicErrorType.EmptyShopItemGroup:
 				errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
-				errorMessageBuilder.Append(DataConstants.EmptyGroupNameMessage);
+				errorMessageBuilder.Append(DataConstants.EmptyShopItemGroupMessage);
 				break;
+			case LogicErrorType.EmptyShopItemTitle:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemTitleMessage);
+                break;
+			case LogicErrorType.EmptyShopItemDescription:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemDescriptionMessage);
+                break;
 			case LogicErrorType.InvalidCost:
                 errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
                 errorMessageBuilder.Append(DataConstants.InvalidItemCostMessage);
@@ -102,14 +110,6 @@ public partial class AddShopItemPage : Popup {
 			case LogicErrorType.InvalidLevel:
                 errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
                 errorMessageBuilder.Append(DataConstants.InvalidLevelMessage);
-                break;
-			case LogicErrorType.EmptyShopItemTitle:
-                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
-                errorMessageBuilder.Append(DataConstants.EmptyShopItemTitleMessage);
-                break;
-			case LogicErrorType.EmptyTaskDescription:
-                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
-                errorMessageBuilder.Append(DataConstants.EmptyShopItemDescriptionMessage);
                 break;
             case LogicErrorType.NegativeShopItemCost:
                 errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
@@ -131,7 +131,7 @@ public partial class AddShopItemPage : Popup {
                 errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
                 errorMessageBuilder.Append(DataConstants.AddShopItemDBErrorMessage);
                 break;
-			default;
+			default:
                 errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
                 errorMessageBuilder.Append(DataConstants.AddShopItemUnknownErrorMessage);
                 break;

--- a/AcademicReward/PopUps/EditShopItemPage.xaml
+++ b/AcademicReward/PopUps/EditShopItemPage.xaml
@@ -4,7 +4,8 @@
             xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
             x:Class="AcademicReward.EditShopItemPage"
             CanBeDismissedByTappingOutsideOfPopup="False"
-            Color="White">
+            Color="White"
+            Size="600, 1100">
     <!-- Primary Author: Sean Stille -->
     <!-- Secondary Author: Wil LaLonde -->
     <!-- Reviewer: Wil LaLonde -->
@@ -19,14 +20,27 @@
                 Margin="10"/>
             <Frame BorderColor="{StaticResource BlueButton}" VerticalOptions="Center" HorizontalOptions="StartAndExpand">
                 <Label
-                    Text="Edit Shop Item"
+                    Text="Update Shop Item"
                     FontSize="50"
                     FontAttributes="Bold"
                     VerticalOptions="Center"
                     TextDecorations="Underline"/>
             </Frame>
         </StackLayout>
-
+        <Frame x:Name="ErrorFrame" BackgroundColor="{StaticResource ErrorBackgroundColor}" BorderColor="{StaticResource ErrorBorderColor}"  Margin="10, 0">
+            <StackLayout x:Name="ErrorStackLayout">
+                <Label
+                    Text="Error while updating shop item: "
+                    x:Name="ErrorMessageHeader"
+                    FontSize="22"
+                    Margin="0, 5"
+                    FontAttributes="Bold"/>
+                <Label
+                    Text=""
+                    x:Name="ErrorMessageBody"
+                    FontSize="20"/>
+            </StackLayout>
+        </Frame>
         <StackLayout Margin="10">
             <Label
                 Text="Item Name:"
@@ -71,26 +85,13 @@
                 FontAttributes="Bold"
                 VerticalOptions="Center"/>
             <Frame BackgroundColor="{StaticResource Gray200}" BorderColor="{StaticResource Gray200}" Margin="0, 5">
-                <Picker Title="Select A Group..." x:Name="GroupPicker" FontSize="20">
-                    <Picker.ItemsSource>
-                        <x:Array Type="{x:Type x:String}">
-                            <x:String>Group 1</x:String>
-                            <x:String>Group 2</x:String>
-                            <x:String>Group 3</x:String>
-                            <x:String>Group 4</x:String>
-                            <x:String>Group 5</x:String>
-                            <x:String>Group 6</x:String>
-                            <x:String>Group 7</x:String>
-                            <x:String>Group 8</x:String>
-                        </x:Array>
-                    </Picker.ItemsSource>
-                </Picker>
+                <Picker Title="Select A Group..." x:Name="GroupPicker" FontSize="20"/>
             </Frame>
         </StackLayout>
         <StackLayout VerticalOptions="EndAndExpand" HorizontalOptions="Center" Margin="10">
             <Button 
                 Text="Update" 
-                Clicked="AddClicked"
+                Clicked="UpdateClicked"
                 FontSize="25"
                 FontFamily="BoldFont"
                 BorderColor="{StaticResource BlueButton}"/>

--- a/AcademicReward/PopUps/EditShopItemPage.xaml.cs
+++ b/AcademicReward/PopUps/EditShopItemPage.xaml.cs
@@ -4,6 +4,8 @@ using AcademicReward.Logic;
 using AcademicReward.ModelClass;
 using AcademicReward.Views;
 using CommunityToolkit.Maui.Views;
+using System.Text;
+using AcademicReward.Resources;
 
 /// <summary>
 /// EditShopItemPage is the popup to edit a shop item
@@ -12,9 +14,9 @@ using CommunityToolkit.Maui.Views;
 /// Reviewer: Wil LaLonde
 /// </summary>
 public partial class EditShopItemPage : Popup {
-	ILogic logic;
-	ShopItem changing;
-	ShopPage page;
+	ILogic shopLogic;
+	ShopItem shopItem;
+	ShopPage shopPage;
 
 	/// <summary>
 	/// EditShopItemPage constructor
@@ -24,28 +26,60 @@ public partial class EditShopItemPage : Popup {
 	/// <param name="shop">ShopPage shop</param>
 	public EditShopItemPage(ILogic ShopLogic, ShopItem toBeChanged, ShopPage shop) {
 		InitializeComponent();
-		logic = ShopLogic;
-		changing = toBeChanged;
-		page = shop;
-		
-	}
+		shopLogic = ShopLogic;
+        shopItem = toBeChanged;
+        shopPage = shop;
+        GroupPicker.ItemsSource = MauiProgram.Profile.GroupList;
+        //Setting values to make updating easier for user
+        name.Text = shopItem.Title;
+        description.Text = shopItem.Description;
+        cost.Text = shopItem.PointCost.ToString();
+        levelRec.Text = shopItem.LevelRequirement.ToString();
+        GroupPicker.SelectedItem = shopItem.Group;
+        //Hide all the error elements
+        SetErrorMessageBox(false, string.Empty);
+    }
 
 	/// <summary>
-	/// Method called when a user clicks the add button
+	/// Method called when a user clicks the update button
 	/// </summary>
 	/// <param name="sender">object sender</param>
 	/// <param name="e">EventArgs e</param>
-	private void AddClicked(object sender, EventArgs e) {
-		String itemID = changing.Id + "";
-		String itemName = name.Text;
-		String itemDesc = description.Text;
-		String itemCost = cost.Text;
-		string itemLevel = levelRec.Text;
-		String itemGroup = "";					//Not sure how to pull this from the array of groups
-		String[] itemValues = { name.Text, description.Text, cost.Text, levelRec.Text, itemGroup, itemID };
-		logic.UpdateItem(itemValues);
-		page.getShopItems();					//Updating list, without this i had to press the add item button to refresh
-		Close();
+	private void UpdateClicked(object sender, EventArgs e) {
+        LogicErrorType logicError;
+        Group selectedGroup = GroupPicker.SelectedItem as Group;
+        if (selectedGroup != null) {
+            string itemName = name.Text ?? string.Empty;
+            string itemDescription = description.Text ?? string.Empty;
+            bool isValidItemCost = int.TryParse(cost.Text, out int itemCost);
+            if (isValidItemCost) {
+                bool isValidLevelRequirement = int.TryParse(levelRec.Text, out int levelRequirement);
+                if (isValidLevelRequirement) {
+                    //Create shop item that will replace the old one
+                    ShopItem shopItemToUpdate = new ShopItem(shopItem.Id, itemName, itemDescription, itemCost, levelRequirement, selectedGroup);
+                    logicError = shopLogic.UpdateItem(shopItemToUpdate);
+                    //Shop item was updated successfully
+                    if (LogicErrorType.NoError == logicError) {
+                        //Update shop item values with new ones
+                        shopItem.Title = shopItemToUpdate.Title;
+                        shopItem.Description = shopItemToUpdate.Description;
+                        shopItem.PointCost = shopItemToUpdate.PointCost;
+                        shopItem.LevelRequirement = shopItemToUpdate.LevelRequirement;
+                        shopItem.Group = shopItemToUpdate.Group;
+                        Close(shopItemToUpdate);
+                    }
+                }
+                else {
+                    logicError = LogicErrorType.InvalidLevel;
+                }
+            } else {
+                logicError = LogicErrorType.InvalidCost;
+            }
+        } else {
+            logicError = LogicErrorType.EmptyShopItemGroup;
+        }
+        // There was some kind of error, show messages
+        SetErrorMessageBox(true, SetErrorMessageBody(logicError));
 	}
 
 	/// <summary>
@@ -54,4 +88,75 @@ public partial class EditShopItemPage : Popup {
 	/// <param name="sender">object sender</param>
 	/// <param name="e">EventArgs e</param>
     private void BackButtonClicked(object sender, EventArgs e) => Close();
+
+    /// <summary>
+    /// Helper method used to either show or hide the error message box
+    /// This is done since a popup cannot have another popup
+    /// </summary>
+    /// <param name="isVisible">bool isVisible</param>
+    /// <param name="errorMessage">string errorMessage</param>
+    private void SetErrorMessageBox(bool isVisible, string errorMessage) {
+        ErrorFrame.IsVisible = isVisible;
+        ErrorStackLayout.IsVisible = isVisible;
+        ErrorMessageHeader.IsVisible = isVisible;
+        ErrorMessageBody.IsVisible = isVisible;
+        ErrorMessageBody.Text = errorMessage;
+    }
+
+    /// <summary>
+    /// Helper method used to determine what error message to display.
+    /// </summary>
+    /// <param name="logicError">LogicErrorType logicError</param>
+    /// <returns>string errorMessage</returns>
+    private string SetErrorMessageBody(LogicErrorType logicError) {
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        switch (logicError)
+        {
+            case LogicErrorType.EmptyShopItemGroup:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemGroupMessage);
+                break;
+            case LogicErrorType.EmptyShopItemTitle:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemTitleMessage);
+                break;
+            case LogicErrorType.EmptyShopItemDescription:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.EmptyShopItemDescriptionMessage);
+                break;
+            case LogicErrorType.InvalidCost:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidItemCostMessage);
+                break;
+            case LogicErrorType.InvalidLevel:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidLevelMessage);
+                break;
+            case LogicErrorType.NegativeShopItemCost:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.NegativeShopItemCostMessage);
+                break;
+            case LogicErrorType.NegativeShopItemLevelRequirement:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.NegativeShopItemLevelRequirementMessage);
+                break;
+            case LogicErrorType.InvalidShopItemLength:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidShopItemTitleLengthMessage);
+                break;
+            case LogicErrorType.InvalidShopItemDescriptionLength:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.InvalidShopItemDescriptionLengthMessage);
+                break;
+            case LogicErrorType.UpdateShopItemDBError:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.UpdateShopItemDBErrorMessage);
+                break;
+            default:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.UpdateShopItemUnknownErrorMessage);
+                break;
+        }
+        return errorMessageBuilder.ToString();
+    }
 }

--- a/AcademicReward/Resources/DataConstants.cs
+++ b/AcademicReward/Resources/DataConstants.cs
@@ -110,6 +110,10 @@
         public const string HistoryCreateTaskDescription = "You created {0} task for {1}";
         public const string HistoryAddShopItemTitle = "Shop Item Created";
         public const string HistoryAddShopItemDescription = "You created shop item: {0} for group: {1}.";
+        public const string HistoryUpdateShopItemTitle = "Shop Item Updated";
+        public const string HistoryUpdateShopItemDescription = "You updated shop item: {0} for group: {1}.";
+        public const string HistoryDeleteShopItemTitle = "Shop Item Deleted";
+        public const string HistoryDeleteShopItemDescription = "You deleted shop item: {0} for group: {1}.";
         //History END
 
         //Create Group START
@@ -139,6 +143,7 @@
         //Home Page END
 
         //Shop START
+        public const string EmptyShopItemGroupMessage = "A shop item group must be selected.";
         public const string InvalidItemCostMessage = "Item cost must be a whole numeric value.";
         public const string InvalidLevelMessage = "Level requirement must be a whole numeric value.";
         public const string EmptyShopItemTitleMessage = "Please fill in the item title entry box.";
@@ -149,6 +154,22 @@
         public const string InvalidShopItemDescriptionLengthMessage = "Item description must be between 1-250 characters.";
         public const string AddShopItemDBErrorMessage = "An unexpected database error occurred while adding the shop item.";
         public const string AddShopItemUnknownErrorMessage = "An unknown error occurred while adding the shop item.";
+        public const string UpdateShopItemDBErrorMessage = "An unexpected database error occurred while updating the shop item.";
+        public const string UpdateShopItemUnknownErrorMessage = "An unknown error occurred while updating the shop item.";
+        public const string LookupShopItemDBErrorTitle = "Error Loading Shop Items";
+        public const string LookupShopItemDBErrorMessage = "There was an unexpected error loading your shop items.";
+        public const string AddShopItemSuccessTitle = "Shop Item Add Success!";
+        public const string AddShopItemSuccessMessage = "Your shop item has been added successfully.";
+        public const string UpdateShopItemSuccessTitle = "Shop Item Update Success!";
+        public const string UpdateShopItemSuccessMessage = "Your shop item has been updated successfully.";
+        public const string DeleteShopItemSuccessTitle = "Shop Item Delete Success!";
+        public const string DeleteShopItemSuccessMessage = "Your shop item has been deleted successfully.";
+        public const string BuyShopItemLevelRequirementMessage = "Your level is not high enough.";
+        public const string BuyShopItemNotEnoughPointsMessage = "Not enough points.";
+        public const string BuyShopItemDBErrorMessage = "An unexpected database error occurred while buying the shop item.";
+        public const string BuyShopItemUnknownErrorMessage = "An unknown error occurred while buying the shop item.";
+        public const string BuyShopItemSuccessTitle = "Shop Item Buy Success!";
+        public const string BuyShopItemSuccessMessage = "Your shop item has been bought successfully.";
         //Shop END
 
         //Display Alert START

--- a/AcademicReward/Resources/DataConstants.cs
+++ b/AcademicReward/Resources/DataConstants.cs
@@ -114,6 +114,8 @@
         public const string HistoryUpdateShopItemDescription = "You updated shop item: {0} for group: {1}.";
         public const string HistoryDeleteShopItemTitle = "Shop Item Deleted";
         public const string HistoryDeleteShopItemDescription = "You deleted shop item: {0} for group: {1}.";
+        public const string HistoryBuyShopItemTitle = "Shop Item Bought";
+        public const string HistoryBuyShopItemDescription = "You bought shop item: {0} from group: {1}.";
         //History END
 
         //Create Group START

--- a/AcademicReward/Resources/DataConstants.cs
+++ b/AcademicReward/Resources/DataConstants.cs
@@ -108,6 +108,8 @@
         public const string HistoryCreateNotificationDescription = "You created {0} notification for {1}";
         public const string HistoryCreateTaskTitle = "Task Created";
         public const string HistoryCreateTaskDescription = "You created {0} task for {1}";
+        public const string HistoryAddShopItemTitle = "Shop Item Created";
+        public const string HistoryAddShopItemDescription = "You created shop item: {0} for group: {1}.";
         //History END
 
         //Create Group START
@@ -135,6 +137,19 @@
         public const string TaskApprovedTitle = "Task Approved!";
         public const string TaskApprovedMessage = "Task was succesfully approved. The member will receive their points and XP the next time they sign in.";
         //Home Page END
+
+        //Shop START
+        public const string InvalidItemCostMessage = "Item cost must be a whole numeric value.";
+        public const string InvalidLevelMessage = "Level requirement must be a whole numeric value.";
+        public const string EmptyShopItemTitleMessage = "Please fill in the item title entry box.";
+        public const string EmptyShopItemDescriptionMessage = "Please fill in the item descrription entry box.";
+        public const string NegativeShopItemCostMessage = "Item cost cannot be negative.";
+        public const string NegativeShopItemLevelRequirementMessage = "Level requirement must be at least 1.";
+        public const string InvalidShopItemTitleLengthMessage = "Item title must be between 1-25 characters.";
+        public const string InvalidShopItemDescriptionLengthMessage = "Item description must be between 1-250 characters.";
+        public const string AddShopItemDBErrorMessage = "An unexpected database error occurred while adding the shop item.";
+        public const string AddShopItemUnknownErrorMessage = "An unknown error occurred while adding the shop item.";
+        //Shop END
 
         //Display Alert START
         public const string OK = "OK";

--- a/AcademicReward/Resources/Enumerations.cs
+++ b/AcademicReward/Resources/Enumerations.cs
@@ -63,8 +63,16 @@
         //Task END
 
         //Shop START
+        EmptyShopItemGroup,
         InvalidCost,
         InvalidLevel,
+        EmptyShopItemTitle,
+        EmptyShopItemDescription,
+        NegativeShopItemCost,
+        NegativeShopItemLevelRequirement,
+        InvalidShopItemLength,
+        InvalidShopItemDescriptionLength,
+        AddShopItemDBError,
         UnsuccessfulDBAdd,
         NotEnoughDoubloons,
         NeedHigherLevel,
@@ -130,6 +138,7 @@
         //Task END
 
         //Shop START
+        AddShopItemDBError,
         BuyItemError,
         //Shop END
 

--- a/AcademicReward/Resources/Enumerations.cs
+++ b/AcademicReward/Resources/Enumerations.cs
@@ -72,10 +72,14 @@
         NegativeShopItemLevelRequirement,
         InvalidShopItemLength,
         InvalidShopItemDescriptionLength,
+        LookupAllShopItemsDBError,
         AddShopItemDBError,
+        UpdateShopItemDBError,
+        DeleteShopItemDBError,
         UnsuccessfulDBAdd,
         NotEnoughDoubloons,
         NeedHigherLevel,
+        BuyItemError,
         //Shop END
 
         //History START (history calls are often made from LogicClasses
@@ -139,6 +143,9 @@
 
         //Shop START
         AddShopItemDBError,
+        UpdateShopItemDBError,
+        LookupAllShopItemsDBError,
+        DeleteShopItemDBError,
         BuyItemError,
         //Shop END
 

--- a/AcademicReward/Views/HomePage.xaml.cs
+++ b/AcademicReward/Views/HomePage.xaml.cs
@@ -36,6 +36,8 @@ public partial class HomePage : ContentPage {
         isAdmin = MauiProgram.Profile.IsAdmin;
         PrepareTaskList();
         RefreshTaskList();
+        BindingContext = MauiProgram.Profile;
+        Points.SetBinding(Label.TextProperty, nameof(MauiProgram.Profile.Points));
         UsernameDisplay(isAdmin);
     }
 
@@ -57,7 +59,6 @@ public partial class HomePage : ContentPage {
         }
 		else {
             //Need to map over all member values
-            Points.Text = MauiProgram.Profile.Points.ToString();
             Level.Text = MauiProgram.Profile.Level.ToString();
             ProgressBar.Progress = MauiProgram.Profile.GetCurrentXPDouble();
             Exp.Text = MauiProgram.Profile.GetCurrentXPInt() + DataConstants.SpaceSlashSpace + Profile.LevelUpRequirementInt;

--- a/AcademicReward/Views/ProfilePage.xaml.cs
+++ b/AcademicReward/Views/ProfilePage.xaml.cs
@@ -15,6 +15,8 @@ public partial class ProfilePage : ContentPage {
     /// </summary>
 	public ProfilePage() {
 		InitializeComponent();
+        BindingContext = MauiProgram.Profile;
+        Points.SetBinding(Label.TextProperty, nameof(MauiProgram.Profile.Points));
         UsernameDisplay(MauiProgram.Profile.IsAdmin);
         // If user is an admin, hide PurchaseHistoryBtn
         if (MauiProgram.Profile.IsAdmin) {
@@ -86,8 +88,6 @@ public partial class ProfilePage : ContentPage {
             Exp.IsVisible = false;
         }
         else {
-            //Need to map over all member values
-            Points.Text = MauiProgram.Profile.Points.ToString();
             Level.Text = MauiProgram.Profile.Level.ToString();
             ProgressBar.Progress = MauiProgram.Profile.GetCurrentXPDouble();
             Exp.Text = MauiProgram.Profile.GetCurrentXPInt() + DataConstants.SpaceSlashSpace + Profile.LevelUpRequirementInt;

--- a/AcademicReward/Views/ShopPage.xaml
+++ b/AcademicReward/Views/ShopPage.xaml
@@ -36,6 +36,18 @@
                             BorderColor="{StaticResource BlueButton}"
                             VerticalOptions="Center"
                             HorizontalOptions="EndAndExpand"/>
+                        <StackLayout Orientation="Horizontal" x:Name="PointStack">
+                            <Label
+                                x:Name="PointsLabel"
+                                Text="Points: "
+                                FontSize="35"
+                                VerticalOptions="Center"
+                                HorizontalOptions="EndAndExpand"/>
+                            <Label
+                                x:Name="Points"
+                                FontSize="35"
+                                VerticalOptions="Center"/>
+                        </StackLayout>
                     </StackLayout>
                 </StackLayout>
             </Frame>

--- a/AcademicReward/Views/ViewShopItemPage.xaml
+++ b/AcademicReward/Views/ViewShopItemPage.xaml
@@ -4,7 +4,8 @@
             xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
             x:Class="AcademicReward.ViewShopItemPage"
             CanBeDismissedByTappingOutsideOfPopup="False"
-            Color="White">
+            Color="White"
+            Size="600, 1100">
     <!-- Primary Author: Sean Stille -->
     <!-- Secondary Author: Wil LaLonde -->
     <!-- Reviewer: Wil LaLonde -->
@@ -28,22 +29,27 @@
             </Frame>
         </StackLayout>
         <StackLayout Margin="10" HorizontalOptions="Center">
-            <Frame BorderColor="Black" CornerRadius="0" Padding="0">
+            <Frame BorderColor="Black" CornerRadius="0" Padding="0" MaximumHeightRequest="350" MinimumHeightRequest="350">
                 <Image
                     Source="shop.png"
                     Scale="0.5"/>
             </Frame>
         </StackLayout>
+        <Frame x:Name="ErrorFrame" BackgroundColor="{StaticResource ErrorBackgroundColor}" BorderColor="{StaticResource ErrorBorderColor}"  Margin="10, 0">
+            <StackLayout x:Name="ErrorStackLayout">
+                <Label
+                    Text="Error while buying shop item: "
+                    x:Name="ErrorMessageHeader"
+                    FontSize="22"
+                    Margin="0, 5"
+                    FontAttributes="Bold"/>
+                <Label
+                    Text=""
+                    x:Name="ErrorMessageBody"
+                    FontSize="20"/>
+            </StackLayout>
+        </Frame>
         <StackLayout Margin="10">
-            <Label
-                Text="Item Cost: "
-                FontSize="22"
-                Margin="0, 5"
-                FontAttributes="Bold"
-                VerticalOptions="Center"/>
-            <Frame BackgroundColor="{StaticResource Gray200}" BorderColor="{StaticResource Gray200}" Margin="0, 5">
-                <Label x:Name="Cost" FontSize="20" BackgroundColor="{StaticResource Gray200}"/>
-            </Frame>
             <Label
                 Text="Item Description: "
                 FontSize="22"
@@ -52,6 +58,24 @@
                 VerticalOptions="Center"/>
             <Frame BackgroundColor="{StaticResource Gray200}" BorderColor="{StaticResource Gray200}" Margin="0, 5">
                 <Label x:Name="Desc" FontSize="20" BackgroundColor="{StaticResource Gray200}"/>
+            </Frame>
+            <Label
+                Text="Level Requirement: "
+                FontSize="22"
+                Margin="0, 5"
+                FontAttributes="Bold"
+                VerticalOptions="Center"/>
+            <Frame BackgroundColor="{StaticResource Gray200}" BorderColor="{StaticResource Gray200}" Margin="0, 5">
+                <Label x:Name="LevelRequirement" FontSize="20" BackgroundColor="{StaticResource Gray200}"/>
+            </Frame>
+            <Label
+                Text="Item Cost: "
+                FontSize="22"
+                Margin="0, 5"
+                FontAttributes="Bold"
+                VerticalOptions="Center"/>
+            <Frame BackgroundColor="{StaticResource Gray200}" BorderColor="{StaticResource Gray200}" Margin="0, 5">
+                <Label x:Name="Cost" FontSize="20" BackgroundColor="{StaticResource Gray200}"/>
             </Frame>
         </StackLayout>
         <StackLayout VerticalOptions="EndAndExpand" HorizontalOptions="Center" Margin="10" Orientation="Horizontal">
@@ -65,7 +89,7 @@
                 Margin="10, 0"/>
             <Button 
                 x:Name="EditButton"
-                Text="Edit" 
+                Text="Update" 
                 Clicked="EditClicked"
                 FontSize="25"
                 FontFamily="BoldFont"

--- a/AcademicReward/Views/ViewShopItemPage.xaml.cs
+++ b/AcademicReward/Views/ViewShopItemPage.xaml.cs
@@ -5,6 +5,7 @@ using AcademicReward.ModelClass;
 using AcademicReward.Resources;
 using AcademicReward.Views;
 using CommunityToolkit.Maui.Views;
+using System.Text;
 
 /// <summary>
 /// ViewShopItemPage shows a given shop item
@@ -13,26 +14,10 @@ using CommunityToolkit.Maui.Views;
 /// Reviewer: Wil LaLonde
 /// </summary>
 public partial class ViewShopItemPage : Popup {
-	ShopLogic logic;
-	ShopItem item;
-	ShopPage shop;
+	ShopLogic shopLogic;
+	ShopItem shopItem;
+	ShopPage shopPage;
 	
-	/// <summary>
-	/// ViewShopItemPage constructor
-	/// </summary>
-	/// <param name="viewedItem">ShopItem viewedItem</param>
-	/// <param name="log">ShopLogic log</param>
-	public ViewShopItemPage(ShopItem viewedItem, ShopLogic log) {
-		InitializeComponent();
-		logic = log;
-		item = viewedItem;
-		ItemTitle.Text = item.Title;
-		Desc.Text = item.Description;
-		Cost.Text = item.PointCost + "";
-		shop = null;
-		SetVisibility(MauiProgram.Profile.IsAdmin);
-	}
-
 	/// <summary>
 	/// ViewShopItemPage constructor
 	/// </summary>
@@ -41,25 +26,28 @@ public partial class ViewShopItemPage : Popup {
 	/// <param name="page">ShopPage page</param>
     public ViewShopItemPage(ShopItem viewedItem, ShopLogic log, ShopPage page) {
         InitializeComponent();
-        logic = log;
-        item = viewedItem;
-        ItemTitle.Text = item.Title;
-        Desc.Text = item.Description;
-        Cost.Text = item.PointCost + "";
-		shop = page;
+        shopLogic = log;
+        shopItem = viewedItem;
+        ItemTitle.Text = shopItem.Title;
+        Desc.Text = shopItem.Description;
+		LevelRequirement.Text = shopItem.LevelRequirement.ToString();
+        Cost.Text = shopItem.PointCost.ToString();
+        shopPage = page;
         SetVisibility(MauiProgram.Profile.IsAdmin);
+        //Hide all the error elements
+        SetErrorMessageBox(false, string.Empty);
     }
 
-	private void SetVisibility(bool isAdmin)
-	{
-		if (isAdmin)
-		{
+    /// <summary>
+    /// Helper method to set items on the page to visible or not
+    /// </summary>
+    /// <param name="isAdmin">bool isAdmin</param>
+    private void SetVisibility(bool isAdmin) {
+		if (isAdmin) {
 			EditButton.IsVisible = true;
 			DeleteButton.IsVisible = true;
 			BuyButton.IsVisible = false;
-		}
-		else
-		{
+		} else {
             EditButton.IsVisible = false;
             DeleteButton.IsVisible = false;
             BuyButton.IsVisible = true;
@@ -73,7 +61,7 @@ public partial class ViewShopItemPage : Popup {
 	/// <param name="e">EventArgs e</param>
     private void EditClicked(object sender, EventArgs e) {
 		Close();
-        shop.openEditPage(item);     
+        shopPage.OpenEditPage(shopItem);     
     }
 
 	/// <summary>
@@ -89,34 +77,67 @@ public partial class ViewShopItemPage : Popup {
 	/// <param name="sender">object sender</param>
 	/// <param name="e">EventArgs e</param>
 	private void DeleteClicked(object sender, EventArgs e) {
-		logic.DeleteItem(item);
-	}
-
-
-	private void BuyClicked(object sender, EventArgs e)
-	{
-		Profile profile = MauiProgram.Profile;
-		String title = "Default";
-		String body = "Default";
-		String close = "Close";
-		LogicErrorType result = logic.BuyItem(item);
-		switch (result)
-		{
-			case LogicErrorType.NeedHigherLevel:
-				title = "You need a higher level!";
-				body = $"You are level {profile.Level}, you need to be level {item.LevelRequirement} to purchase this item";
-				break;
-			case LogicErrorType.NotEnoughDoubloons:
-				title = "You need more points!";
-				body = $"This item costs {item.PointCost} points, you only have {profile.Points} points";
-				break;
-			default:
-				break;
-		}
-		if (result != LogicErrorType.NoError)
-		{
-            shop.displayError(title, body, close);
+		LogicErrorType logicError = shopLogic.DeleteItem(shopItem);
+		if(LogicErrorType.NoError == logicError) {
+			shopItem.Id = ShopItem.DeleteShopItemSuccesValue;
         }
-		Close();
+        Close(shopItem);
+    }
+
+	/// <summary>
+	/// Method called when a user clicks on the buy button
+	/// </summary>
+	/// <param name="sender">object sender</param>
+	/// <param name="e">EventArgs e</param>
+	private void BuyClicked(object sender, EventArgs e) {
+		LogicErrorType logicError = shopLogic.BuyItem(shopItem);
+		if (LogicErrorType.NoError == logicError) {
+			shopItem.Id = ShopItem.BuyShopItemSuccessValue;
+            Close(shopItem);
+        }
+        //Something went wrong, show error message
+        SetErrorMessageBox(true, SetErrorMessageBody(logicError));
+    }
+
+    /// <summary>
+    /// Helper method used to either show or hide the error message box
+    /// This is done since a popup cannot have another popup
+    /// </summary>
+    /// <param name="isVisible">bool isVisible</param>
+    /// <param name="errorMessage">string errorMessage</param>
+    private void SetErrorMessageBox(bool isVisible, string errorMessage) {
+        ErrorFrame.IsVisible = isVisible;
+        ErrorStackLayout.IsVisible = isVisible;
+        ErrorMessageHeader.IsVisible = isVisible;
+        ErrorMessageBody.IsVisible = isVisible;
+        ErrorMessageBody.Text = errorMessage;
+    }
+
+	/// <summary>
+	/// Helper method used to determine what error message to display.
+	/// </summary>
+	/// <param name="logicError">LogicErrorType logicError</param>
+	/// <returns>string errorMessage</returns>
+	private string SetErrorMessageBody(LogicErrorType logicError) {
+		StringBuilder errorMessageBuilder = new StringBuilder();
+		switch(logicError) {
+			case LogicErrorType.NeedHigherLevel:
+				errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+				errorMessageBuilder.Append(DataConstants.BuyShopItemLevelRequirementMessage);
+				break;
+            case LogicErrorType.NotEnoughDoubloons:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.BuyShopItemNotEnoughPointsMessage);
+                break;
+            case LogicErrorType.BuyItemError:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.BuyShopItemDBErrorMessage);
+                break;
+			default:
+                errorMessageBuilder.Append(DataConstants.SpaceDashSpace);
+                errorMessageBuilder.Append(DataConstants.BuyShopItemUnknownErrorMessage);
+                break;
+        }
+		return errorMessageBuilder.ToString();
 	}
 }


### PR DESCRIPTION
A complete overhaul of the shop feature. 

There were very few error messages that were shown to the user, there are now plenty (all that I could think of).
Users were able to set unrealistic values when creating a shop item (negative points, negative level, etc.). Added error checking to actually account for that.
Shop items will only show for specific users now. Before, all shop items in the table would show.
Members will only see shop items they have not purchased.
Added binding for points. This will bind on the home, profile, and shop page.
Added plenty of history events as well.
Can now select an actual group when editing a shop item